### PR TITLE
Update for IOS8 Keyboard Size

### DIFF
--- a/ZSSRichTextEditor/ZSSRichTextEditor.m
+++ b/ZSSRichTextEditor/ZSSRichTextEditor.m
@@ -1131,7 +1131,8 @@ static Class hackishFixClass = Nil;
     CGFloat sizeOfToolbar = self.toolbarHolder.frame.size.height;
     
     // Keyboard Size
-    CGFloat keyboardHeight = UIInterfaceOrientationIsLandscape(orientation) ? keyboardEnd.size.width : keyboardEnd.size.height;
+    //Checks if IOS8, gets correct keyboard height
+   CGFloat keyboardHeight = UIInterfaceOrientationIsLandscape(orientation) ? ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.000000) ? keyboardEnd.size.height : keyboardEnd.size.width : keyboardEnd.size.height;
     
     // Correct Curve
     UIViewAnimationOptions animationOptions = curve << 16;


### PR DESCRIPTION
Fixes the landscape view frame issue
Toolbar works in landscape and moves with the QuickType Bar
