### PR TITLE
Only show Toolbar if ZSSRichTextEditor is First Responder

### DIFF
--- a/ZSSRichTextEditor.xcodeproj/project.pbxproj
+++ b/ZSSRichTextEditor.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		45F860C618A84CFA0011266B /* ZSSunlink@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 45F860A418A84CFA0011266B /* ZSSunlink@2x.png */; };
 		45F860C718A84CFA0011266B /* ZSSunorderedlist@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 45F860A518A84CFA0011266B /* ZSSunorderedlist@2x.png */; };
 		45F860C818A84CFA0011266B /* ZSSviewsource@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 45F860A618A84CFA0011266B /* ZSSviewsource@2x.png */; };
+		BED7ED8F3236FDABAE361778 /* UIResponder+ZSSFirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = BED7E5F18AFFD2580FD3506F /* UIResponder+ZSSFirstResponder.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -252,6 +253,8 @@
 		45F860A418A84CFA0011266B /* ZSSunlink@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "ZSSunlink@2x.png"; path = "Images/ZSSunlink@2x.png"; sourceTree = "<group>"; };
 		45F860A518A84CFA0011266B /* ZSSunorderedlist@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "ZSSunorderedlist@2x.png"; path = "Images/ZSSunorderedlist@2x.png"; sourceTree = "<group>"; };
 		45F860A618A84CFA0011266B /* ZSSviewsource@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "ZSSviewsource@2x.png"; path = "Images/ZSSviewsource@2x.png"; sourceTree = "<group>"; };
+		BED7E5F18AFFD2580FD3506F /* UIResponder+ZSSFirstResponder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIResponder+ZSSFirstResponder.m"; sourceTree = "<group>"; };
+		BED7ED711102A36704E04897 /* UIResponder+ZSSFirstResponder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIResponder+ZSSFirstResponder.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -463,6 +466,7 @@
 				456A5977189C58C400FAEF89 /* Views */,
 				4581EBB9184B0F5C0048CAB0 /* ZSSRichTextEditor.h */,
 				4581EBBA184B0F5C0048CAB0 /* ZSSRichTextEditor.m */,
+				BED7E6581A4AF6344DB37BB4 /* FirstResponder */,
 			);
 			name = ZSRichTextEditor;
 			sourceTree = "<group>";
@@ -504,6 +508,15 @@
 				45A0CA4B18A8522A00F3F35E /* HRColorUtil.m */,
 			);
 			path = ColorPicker;
+			sourceTree = "<group>";
+		};
+		BED7E6581A4AF6344DB37BB4 /* FirstResponder */ = {
+			isa = PBXGroup;
+			children = (
+				BED7E5F18AFFD2580FD3506F /* UIResponder+ZSSFirstResponder.m */,
+				BED7ED711102A36704E04897 /* UIResponder+ZSSFirstResponder.h */,
+			);
+			name = FirstResponder;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -677,6 +690,7 @@
 				4581EBB81848F8190048CAB0 /* ZSSDemoViewController.m in Sources */,
 				45F80458189B1E9300A1EDD9 /* ZSSDemoPickerViewController.m in Sources */,
 				4513B3D8184E8F5100A9CA86 /* ZSSBarButtonItem.m in Sources */,
+				BED7ED8F3236FDABAE361778 /* UIResponder+ZSSFirstResponder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ZSSRichTextEditor/UIResponder+ZSSFirstResponder.h
+++ b/ZSSRichTextEditor/UIResponder+ZSSFirstResponder.h
@@ -1,0 +1,11 @@
+// taken from
+// http://stackoverflow.com/a/14135456/354018
+// http://stackoverflow.com/a/11768282/354018
+
+@interface UIResponder (ZSSFirstResponder)
+
++ (void)zss_resignFirstResponder;
++ (UIResponder *)zss_currentFirstResponder;
++ (BOOL)zss_isInResponderChain:(UIResponder *)responder;
+
+@end

--- a/ZSSRichTextEditor/UIResponder+ZSSFirstResponder.m
+++ b/ZSSRichTextEditor/UIResponder+ZSSFirstResponder.m
@@ -1,0 +1,46 @@
+#import "UIResponder+ZSSFirstResponder.h"
+
+
+static __weak id zss_currentFirstResponder = nil;
+
+
+@implementation UIResponder (ZSSFirstResponder)
+
++ (void)zss_resignFirstResponder {
+
+	[[UIApplication sharedApplication] sendAction:@selector(resignFirstResponder) to:nil from:nil forEvent:nil];
+}
+
++ (UIResponder *)zss_currentFirstResponder {
+
+	zss_currentFirstResponder = nil;
+	[[UIApplication sharedApplication] sendAction:@selector(zss_findFirstResponder) to:nil from:nil forEvent:nil];
+	return zss_currentFirstResponder;
+}
+
+- (void)zss_findFirstResponder {
+
+	zss_currentFirstResponder = self;
+}
+
++ (BOOL)zss_isInResponderChain:(UIResponder *)responder {
+
+	id firstResponder = [UIResponder zss_currentFirstResponder];
+	return [UIResponder zss_isInResponderChain:responder responderInFirstResponderChain:firstResponder];
+}
+
++ (BOOL)zss_isInResponderChain:(UIResponder *)responderToCheck responderInFirstResponderChain:(UIResponder *)responderInFirstResponderChain {
+
+	if (responderInFirstResponderChain == nil) {
+		return NO;
+	}
+
+	if (responderToCheck == responderInFirstResponderChain) {
+		return YES;
+	}
+
+	UIResponder *nextResponder = [responderInFirstResponderChain nextResponder];
+	return [UIResponder zss_isInResponderChain:responderToCheck responderInFirstResponderChain:nextResponder];
+}
+
+@end

--- a/ZSSRichTextEditor/ZSSRichTextEditor.m
+++ b/ZSSRichTextEditor/ZSSRichTextEditor.m
@@ -12,6 +12,7 @@
 #import "ZSSBarButtonItem.h"
 #import "HRColorUtil.h"
 #import "ZSSTextView.h"
+#import "UIResponder+ZSSFirstResponder.h"
 
 
 @interface UIWebView (HackishAccessoryHiding)
@@ -1136,10 +1137,14 @@ static Class hackishFixClass = Nil;
     
     // Correct Curve
     UIViewAnimationOptions animationOptions = curve << 16;
-    
-	if ([notification.name isEqualToString:UIKeyboardWillShowNotification]) {
+
+    BOOL isInFirstResponderChain = [UIResponder zss_isInResponderChain:self.view];
+
+	if (isInFirstResponderChain && [notification.name isEqualToString:UIKeyboardWillShowNotification]) {
         
         [UIView animateWithDuration:duration delay:0 options:animationOptions animations:^{
+
+            self.toolbarHolder.alpha = 1.0f;
             
             // Toolbar
             CGRect frame = self.toolbarHolder.frame;
@@ -1170,7 +1175,9 @@ static Class hackishFixClass = Nil;
 	} else {
         
 		[UIView animateWithDuration:duration delay:0 options:animationOptions animations:^{
-            
+
+            self.toolbarHolder.alpha = isInFirstResponderChain ? 1.0f : 0.0f;
+
             CGRect frame = self.toolbarHolder.frame;
             frame.origin.y = self.view.frame.size.height + keyboardHeight;
             self.toolbarHolder.frame = frame;


### PR DESCRIPTION
(!) not yet ready to merge

This fixes a part of #65.

**Use Case**: A view with several `UITextField`s + `ZSSRichTextEditor` in a container view.

**Fix Idea:** In `keyboardWillShowOrHide:` check if `ZSSRichTextEditor` really is the first responder. If not, do not show the toolbar.

**What Works:** If the keyboard is not shown and a `UITextField` becomes active, the toolbar is not shown. When `ZSSRichTextEditor` becomes active the toolbar shows up.

**Open Problems:** When `ZSSRichTextEditor` is active and the keyboard is visible, and the `UITextField` becomes active, the toolbar stays visible. This is due to the keyboard notifications not getting triggered when the `UITextField` becomes active, as the keyboard is already showing, and the `UITextField` does not have an `inputAccessoryView`.

Any ideas how to fix this completely?