### PR TITLE
Fix selection lost after insertNode to range.

### DIFF
--- a/ZSSRichTextEditor/ZSSRichTextEditor.js
+++ b/ZSSRichTextEditor/ZSSRichTextEditor.js
@@ -141,6 +141,7 @@ zss_editor.getCaretYPosition = function() {
     //sel.collapseToStart();
     var range = sel.getRangeAt(0);
     var span = document.createElement('span');// something happening here preventing selection of elements
+    range.collapse(false);
     range.insertNode(span);
     var topPosition = span.offsetTop;
     span.parentNode.removeChild(span);


### PR DESCRIPTION
Selection will be set to " " after insertNode to range. This issue causes some functions in editor broken, such as Bold.

To reproduce this issue, 
1.  Double-tap a word in text node, just like 'This' in the demo view.
2.  Click 'Bold' button, <b> tag will not be inserted to these text range.
