### PR TITLE
Add support for custom CSS.

### DIFF
--- a/ZSSRichTextEditor/Source/ZSSRichTextEditor.h
+++ b/ZSSRichTextEditor/Source/ZSSRichTextEditor.h
@@ -190,6 +190,11 @@ static NSString * const ZSSRichTextEditorToolbarNone = @"com.zedsaid.toolbaritem
 - (void)addCustomToolbarItem:(ZSSBarButtonItem *)item;
 
 /**
+ *  Add a custom block of CSS
+ */
+- (void)addCSS:(NSString*)css;
+
+/**
  *  Scroll event callback with position
  */
 - (void)editorDidScrollWithPosition:(NSInteger)position;

--- a/ZSSRichTextEditor/Source/ZSSRichTextEditor.js
+++ b/ZSSRichTextEditor/Source/ZSSRichTextEditor.js
@@ -636,7 +636,7 @@ zss_editor.blurEditor = function() {
     $('#zss_editor_content').blur();
 }
 
-zss_editor.addCSS = function(css){
+zss_editor.addCSS = function(css) {
     var currentCSS = $('head').find('style').html();
     $('head').find('style').html(currentCSS + css);
 };

--- a/ZSSRichTextEditor/Source/ZSSRichTextEditor.js
+++ b/ZSSRichTextEditor/Source/ZSSRichTextEditor.js
@@ -634,4 +634,11 @@ zss_editor.focusEditor = function() {
 
 zss_editor.blurEditor = function() {
     $('#zss_editor_content').blur();
-}//end
+}
+
+zss_editor.addCSS = function(css){
+    var currentCSS = $('head').find('style').html();
+    $('head').find('style').html(currentCSS + css);
+};
+
+//end

--- a/ZSSRichTextEditor/Source/ZSSRichTextEditor.m
+++ b/ZSSRichTextEditor/Source/ZSSRichTextEditor.m
@@ -910,6 +910,10 @@ static Class hackishFixClass = Nil;
     [self buildToolbar];
 }
 
+- (void)addCSS:(NSString *)css {
+    NSString *javascript = [NSString stringWithFormat:@"zss_editor.addCSS('%@');", css];
+    [self.editorView stringByEvaluatingJavaScriptFromString:javascript];
+}
 
 - (void)removeLink {
     [self.editorView stringByEvaluatingJavaScriptFromString:@"zss_editor.unlink();"];


### PR DESCRIPTION
This allows a ZSSRichTextEditor subclass to add css like so:

```
[self addCSS:@"h1 {font-size: 21px !important; margin: 10px 0px 15px 0px !important;}"];
```

I can add something to the readme if you like this idea. It's cool if you aren't crazy about it. I just needed for something I'm working on and figured I'd send a PR in case anyone would like to see it.