### PR TITLE
Fixed toolbar button status not updated on select text

### DIFF
--- a/ZSSRichTextEditor/Source/ZSSRichTextEditor.js
+++ b/ZSSRichTextEditor/Source/ZSSRichTextEditor.js
@@ -49,6 +49,7 @@ zss_editor.init = function() {
     $(document).on('selectionchange',function(e){
                    zss_editor.calculateEditorHeightWithCaretPosition();
                    zss_editor.setScrollPosition();
+                   zss_editor.enabledEditingItems(e);
                    });
     
     $(window).on('scroll', function(e) {
@@ -60,6 +61,7 @@ zss_editor.init = function() {
                  zss_editor.isDragging = true;
                  zss_editor.updateScrollOffset = true;
                  zss_editor.setScrollPosition();
+                 zss_editor.enabledEditingItems(e);
                  });
     $(window).on('touchstart', function(e) {
                  zss_editor.isDragging = false;
@@ -563,7 +565,8 @@ zss_editor.enabledEditingItems = function(e) {
     if (typeof(e) != "undefined") {
         
         // The target element
-        var t = $(e.target);
+        var s = zss_editor.getSelectedNode();
+        var t = $(s);
         var nodeName = e.target.nodeName.toLowerCase();
         
         // Background Color


### PR DESCRIPTION
Refer to [issue #112 ](https://github.com/nnhubbard/ZSSRichTextEditor/issues/112)

Caused by two reasons:
1. enabledEditingItems is not called when select text and apply the html style
2. js runtime error in enabledEditingItems. e.target is always document, it should change to the current selected node