### PR TITLE
Fix toolbar is not fit the screen width on iPhone 6, 6+

### DIFF
--- a/ZSSRichTextEditor/Source/ZSSRichTextEditor.m
+++ b/ZSSRichTextEditor/Source/ZSSRichTextEditor.m
@@ -143,7 +143,8 @@ static Class hackishFixClass = Nil;
     self.toolBarScroll.showsHorizontalScrollIndicator = NO;
     
     // Toolbar with icons
-    self.toolbar = [[UIToolbar alloc] initWithFrame:self.toolBarScroll.frame];
+    self.toolbar = [[UIToolbar alloc] initWithFrame:CGRectZero];
+    self.toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     self.toolbar.backgroundColor = [UIColor clearColor];
     [self.toolBarScroll addSubview:self.toolbar];
     self.toolBarScroll.autoresizingMask = self.toolbar.autoresizingMask;


### PR DESCRIPTION
Fix toolbar is not fit the screen width on iPhone 6, 6+